### PR TITLE
[Dark Factory] Add a new `/about` route with a Tailwind-styled About page that reuses the existing app layout/theme, displaying app name, `1.0.0` version badge, and a short description in 2–3 sentences.

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,16 +1,62 @@
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/pages/dashboard-page", () => ({
-  default: () => <div>Dashboard page</div>,
+  default: () => <main data-testid="dashboard-page">Dashboard Page</main>
+}));
+
+vi.mock("@/pages/about-page", () => ({
+  default: () => <main data-testid="about-page">About Page</main>
 }));
 
 import App from "@/App";
 
-describe("App", () => {
-  it("renders DashboardPage", () => {
-    render(<App />);
-    expect(screen.getByText("Dashboard page")).toBeInTheDocument();
+const renderAt = (path: string): void => {
+  window.history.pushState({}, "", path);
+  render(<App />);
+};
+
+describe("App routing", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("renders DashboardPage on the root route", () => {
+    renderAt("/");
+
+    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("about-page")).not.toBeInTheDocument();
+  });
+
+  it("renders AboutPage on /about", () => {
+    renderAt("/about");
+
+    expect(screen.getByTestId("about-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-page")).not.toBeInTheDocument();
+  });
+
+  it("redirects unknown routes to root and renders DashboardPage", async () => {
+    renderAt("/does-not-exist");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/");
+    });
+    expect(screen.queryByTestId("about-page")).not.toBeInTheDocument();
+  });
+
+  it("redirects unknown deep paths (with query/hash) to root", async () => {
+    renderAt("/bad/path?foo=1#section");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/");
+    });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+
+import AboutPage from "@/pages/about-page";
 import DashboardPage from "@/pages/dashboard-page";
 
 const App = (): JSX.Element => {
-  return <DashboardPage />;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
 };
 
 export default App;

--- a/src/pages/about-page.test.tsx
+++ b/src/pages/about-page.test.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AboutPage from "@/pages/about-page";
+
+vi.mock("@/components/layout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="layout-shell">{children}</div>
+}));
+
+describe("AboutPage", () => {
+  it("renders inside Layout and shows the page title/version", () => {
+    render(<AboutPage />);
+
+    expect(screen.getByTestId("layout-shell")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Cashflow Dashboard" })).toBeInTheDocument();
+    expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+  });
+
+  it("renders all descriptive paragraphs", () => {
+    render(<AboutPage />);
+
+    expect(
+      screen.getByText("Cashflow Dashboard helps teams track incoming and outgoing cash in one place.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "It provides a clear snapshot of balances, trends, and recent activity so decisions can be made quickly."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The interface is designed for fast daily use, with responsive layouts and dark mode support."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders stable key content exactly once", () => {
+    render(<AboutPage />);
+
+    expect(screen.getAllByRole("heading", { level: 1, name: "Cashflow Dashboard" })).toHaveLength(1);
+    expect(screen.getAllByText("v1.0.0")).toHaveLength(1);
+  });
+});

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,0 +1,30 @@
+import Layout from "@/components/layout";
+
+const AboutPage = (): JSX.Element => {
+  return (
+    <Layout>
+      <section className="space-y-4 sm:space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Cashflow Dashboard</h1>
+          <span className="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300">
+            v1.0.0
+          </span>
+        </div>
+
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 lg:p-8 dark:border-slate-800 dark:bg-slate-950">
+          <p className="text-sm leading-6 text-slate-700 dark:text-slate-300">
+            Cashflow Dashboard helps teams track incoming and outgoing cash in one place.
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+            It provides a clear snapshot of balances, trends, and recent activity so decisions can be made quickly.
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+            The interface is designed for fast daily use, with responsive layouts and dark mode support.
+          </p>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default AboutPage;


### PR DESCRIPTION
## Dark Factory — Automated PR

> Generated by pipeline job `cmm6vm3dh0002145y76l65n7z`
> ⚠️ This implementation required **2 retry iterations**

### Implementation Plan
1. **create** `src/pages/about-page.tsx`
2. **modify** `src/App.tsx`
3. **modify** `src/App.tsx`

### Code Review Verdict
✅ Approved

**Issues flagged:**
- [minor] `src/pages/about-page.tsx`: The badge shows `v1.0.0` while the spec explicitly calls for version `1.0.0`. If strict spec matching is required, remove the `v` prefix.
- [suggestion] `src/App.test.tsx`: Routing behavior introduced in `App.tsx` (`/about` and `*` redirect) is not covered by tests. Add route-focused tests (e.g., using MemoryRouter or mocked location) to prevent regressions.

### Pipeline Cost
**Total: $0.4036 USD**

| Agent | Model | Notes |
|---|---|---|
| planner | gpt-5.3-codex | — |
| coder | gpt-5.3-codex | — |
| reviewer | gpt-5.3-codex | — |
| tester | gpt-5.3-codex | — |
| designer | gpt-5.3-codex | — |
| validator | gpt-5.3-codex | — |

---
_This PR was opened automatically by [Dark Factory v4](https://github.com/ibuzzardo/dark-factory-v4)._