### PR TITLE
[Dark Factory] Implement a new `/dashboard/notifications` page with typed notification models, mock data, UI behavior (icons + Mark All Read), and tests for filtering logic while aligning with existing app shell/layout and TypeScript/Tailwind/shadcn conventions.

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,16 +1,64 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/pages/dashboard-page", () => ({
-  default: () => <div>Dashboard page</div>,
+  default: () => <div data-testid="dashboard-page">Dashboard page</div>,
+}));
+
+vi.mock("@/pages/notifications-page", () => ({
+  default: () => <div data-testid="notifications-page">Notifications page</div>,
 }));
 
 import App from "@/App";
 
 describe("App", () => {
-  it("renders DashboardPage", () => {
+  beforeEach((): void => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("renders DashboardPage on default route", () => {
     render(<App />);
-    expect(screen.getByText("Dashboard page")).toBeInTheDocument();
+
+    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("notifications-page")).not.toBeInTheDocument();
+  });
+
+  it("renders NotificationsPage on /dashboard/notifications", () => {
+    window.history.pushState({}, "", "/dashboard/notifications");
+
+    render(<App />);
+
+    expect(screen.getByTestId("notifications-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-page")).not.toBeInTheDocument();
+  });
+
+  it("renders NotificationsPage when query string/hash are present", () => {
+    window.history.pushState({}, "", "/dashboard/notifications?tab=all#latest");
+
+    render(<App />);
+
+    expect(screen.getByTestId("notifications-page")).toBeInTheDocument();
+  });
+
+  it("falls back to DashboardPage for unknown routes", () => {
+    window.history.pushState({}, "", "/dashboard/notifications/archive");
+
+    render(<App />);
+
+    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("notifications-page")).not.toBeInTheDocument();
+  });
+
+  it("re-evaluates the route on re-render", () => {
+    const { rerender } = render(<App />);
+
+    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+
+    window.history.pushState({}, "", "/dashboard/notifications");
+    rerender(<App />);
+
+    expect(screen.getByTestId("notifications-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-page")).not.toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,21 @@
 import DashboardPage from "@/pages/dashboard-page";
+import NotificationsPage from "@/pages/notifications-page";
+
+const getCurrentPath = (): string => {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+
+  return window.location.pathname;
+};
 
 const App = (): JSX.Element => {
+  const currentPath = getCurrentPath();
+
+  if (currentPath === "/dashboard/notifications") {
+    return <NotificationsPage />;
+  }
+
   return <DashboardPage />;
 };
 

--- a/src/pages/notifications-page.tsx
+++ b/src/pages/notifications-page.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from "react";
+
+import Layout from "@/components/layout";
+import type { Notification } from "@/types/notification";
+
+type NotificationFilter = "all" | Notification["type"];
+
+const FILTER_OPTIONS: ReadonlyArray<{ label: string; value: NotificationFilter }> = [
+  { label: "All", value: "all" },
+  { label: "Info", value: "info" },
+  { label: "Warning", value: "warning" },
+  { label: "Error", value: "error" },
+];
+
+const TYPE_ICON: Record<Notification["type"], string> = {
+  info: "i",
+  warning: "!",
+  error: "x",
+};
+
+const TYPE_BADGE_CLASS: Record<Notification["type"], string> = {
+  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200",
+  warning: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200",
+  error: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200",
+};
+
+export const mockNotifications: Notification[] = [
+  {
+    id: "n-1",
+    title: "Budget synced",
+    message: "Your latest account balances are now available.",
+    type: "info",
+    timestamp: "2026-02-28T08:00:00.000Z",
+    read: false,
+  },
+  {
+    id: "n-2",
+    title: "Large expense detected",
+    message: "A transaction above your alert threshold was recorded.",
+    type: "warning",
+    timestamp: "2026-02-27T19:10:00.000Z",
+    read: false,
+  },
+  {
+    id: "n-3",
+    title: "Import failed",
+    message: "We could not process one CSV row. Please review and retry.",
+    type: "error",
+    timestamp: "2026-02-27T13:30:00.000Z",
+    read: true,
+  },
+  {
+    id: "n-4",
+    title: "Monthly summary ready",
+    message: "Your February cashflow summary has been generated.",
+    type: "info",
+    timestamp: "2026-02-26T21:00:00.000Z",
+    read: true,
+  },
+  {
+    id: "n-5",
+    title: "Category limit nearing",
+    message: "Food spending is at 90% of your configured monthly target.",
+    type: "warning",
+    timestamp: "2026-02-25T17:45:00.000Z",
+    read: false,
+  },
+];
+
+export const filterNotificationsByType = (
+  notifications: Notification[],
+  type: NotificationFilter,
+): Notification[] => {
+  if (type === "all") {
+    return notifications;
+  }
+
+  return notifications.filter((notification: Notification) => notification.type === type);
+};
+
+const formatTimestamp = (timestamp: string): string => {
+  return new Date(timestamp).toLocaleString();
+};
+
+const NotificationsPage = (): JSX.Element => {
+  const [notifications, setNotifications] = useState<Notification[]>(mockNotifications);
+  const [activeFilter, setActiveFilter] = useState<NotificationFilter>("all");
+
+  const filteredNotifications = useMemo((): Notification[] => {
+    return filterNotificationsByType(notifications, activeFilter);
+  }, [notifications, activeFilter]);
+
+  const markAllRead = (): void => {
+    setNotifications((current: Notification[]): Notification[] => {
+      return current.map((notification: Notification): Notification => ({
+        ...notification,
+        read: true,
+      }));
+    });
+  };
+
+  const allRead = notifications.every((notification: Notification): boolean => notification.read);
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+        <main className="mx-auto w-full max-w-5xl p-4 md:p-6">
+          <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">System updates, warnings, and alerts</p>
+            </div>
+            <button
+              type="button"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:w-auto"
+              onClick={markAllRead}
+              disabled={allRead}
+            >
+              Mark All Read
+            </button>
+          </header>
+
+          <section className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="inline-flex w-full flex-wrap gap-2 rounded-lg bg-slate-100 p-1 md:w-auto dark:bg-slate-900">
+              {FILTER_OPTIONS.map((option: { label: string; value: NotificationFilter }) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    activeFilter === option.value
+                      ? "bg-white text-slate-900 shadow-sm dark:bg-slate-800 dark:text-slate-100"
+                      : "text-slate-600 hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800"
+                  }`}
+                  onClick={(): void => setActiveFilter(option.value)}
+                  aria-pressed={activeFilter === option.value}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 md:space-y-4">
+            {filteredNotifications.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center dark:border-slate-700 dark:bg-slate-900">
+                <p className="text-sm text-slate-600 dark:text-slate-300">No notifications for this type.</p>
+              </div>
+            ) : (
+              filteredNotifications.map((notification: Notification) => (
+                <article
+                  key={notification.id}
+                  className="w-full rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition-colors hover:bg-slate-50 focus-within:ring-2 focus-within:ring-blue-500 md:p-5 dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800"
+                >
+                  <div className="flex items-start gap-3">
+                    <span
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold uppercase text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                      aria-label={`${notification.type} notification`}
+                    >
+                      {TYPE_ICON[notification.type]}
+                    </span>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-sm font-semibold md:text-base">{notification.title}</h2>
+                        <span
+                          className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${TYPE_BADGE_CLASS[notification.type]}`}
+                        >
+                          {notification.type}
+                        </span>
+                        {!notification.read ? (
+                          <span className="inline-flex items-center rounded-md bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-200">
+                            Unread
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{notification.message}</p>
+                      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                        {formatTimestamp(notification.timestamp)}
+                      </p>
+                    </div>
+                  </div>
+                </article>
+              ))
+            )}
+          </section>
+        </main>
+      </div>
+    </Layout>
+  );
+};
+
+export default NotificationsPage;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,8 @@
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  type: "info" | "warning" | "error";
+  timestamp: string;
+  read: boolean;
+}

--- a/tests/notification-type.test.ts
+++ b/tests/notification-type.test.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { Notification } from "../src/types/notification";
+
+describe("Notification type", () => {
+  it("enforces the expected shape", () => {
+    const notification: Notification = {
+      id: "n-100",
+      title: "Sample title",
+      message: "Sample message",
+      type: "info",
+      timestamp: "2026-02-28T08:00:00.000Z",
+      read: false,
+    };
+
+    expectTypeOf(notification.id).toBeString();
+    expectTypeOf(notification.title).toBeString();
+    expectTypeOf(notification.message).toBeString();
+    expectTypeOf(notification.type).toEqualTypeOf<"info" | "warning" | "error">();
+    expectTypeOf(notification.timestamp).toBeString();
+    expectTypeOf(notification.read).toBeBoolean();
+  });
+});

--- a/tests/notifications-page.integration.test.tsx
+++ b/tests/notifications-page.integration.test.tsx
@@ -1,0 +1,64 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/layout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+import NotificationsPage, { mockNotifications } from "@/pages/notifications-page";
+
+describe("NotificationsPage", () => {
+  it("renders inside Layout and shows all filter options", () => {
+    render(<NotificationsPage />);
+
+    expect(screen.getByTestId("layout")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Info" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Warning" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Error" })).toBeInTheDocument();
+  });
+
+  it("shows all mock notifications by default", () => {
+    render(<NotificationsPage />);
+
+    for (const notification of mockNotifications) {
+      expect(screen.getByText(notification.title)).toBeInTheDocument();
+      expect(screen.getByText(notification.message)).toBeInTheDocument();
+    }
+  });
+
+  it("filters the list to warning notifications", async () => {
+    const user = userEvent.setup();
+
+    render(<NotificationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Warning" }));
+
+    expect(screen.getByText("Large expense detected")).toBeInTheDocument();
+    expect(screen.getByText("Category limit nearing")).toBeInTheDocument();
+
+    expect(screen.queryByText("Budget synced")).not.toBeInTheDocument();
+    expect(screen.queryByText("Import failed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Monthly summary ready")).not.toBeInTheDocument();
+  });
+
+  it("filters to error notifications and can switch back to all", async () => {
+    const user = userEvent.setup();
+
+    render(<NotificationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Error" }));
+
+    expect(screen.getByText("Import failed")).toBeInTheDocument();
+    expect(screen.queryByText("Budget synced")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "All" }));
+
+    for (const notification of mockNotifications) {
+      expect(screen.getByText(notification.title)).toBeInTheDocument();
+    }
+  });
+});

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { filterNotificationsByType, mockNotifications } from "../src/pages/notifications-page";
+import type { Notification } from "../src/types/notification";
+
+const notificationsFixture: Notification[] = [
+  {
+    id: "t-1",
+    title: "Info item",
+    message: "Informational notice",
+    type: "info",
+    timestamp: "2026-02-28T10:00:00.000Z",
+    read: false,
+  },
+  {
+    id: "t-2",
+    title: "Warning item",
+    message: "Warning notice",
+    type: "warning",
+    timestamp: "2026-02-28T11:00:00.000Z",
+    read: true,
+  },
+  {
+    id: "t-3",
+    title: "Error item",
+    message: "Error notice",
+    type: "error",
+    timestamp: "2026-02-28T12:00:00.000Z",
+    read: false,
+  },
+  {
+    id: "t-4",
+    title: "Second info",
+    message: "Another informational notice",
+    type: "info",
+    timestamp: "2026-02-28T13:00:00.000Z",
+    read: true,
+  },
+];
+
+describe("filterNotificationsByType", () => {
+  it("returns all notifications when filter is all", () => {
+    const result = filterNotificationsByType(notificationsFixture, "all");
+
+    expect(result).toHaveLength(4);
+    expect(result.map((notification: Notification) => notification.id)).toEqual(["t-1", "t-2", "t-3", "t-4"]);
+  });
+
+  it("returns the exact same array reference when filter is all", () => {
+    const result = filterNotificationsByType(notificationsFixture, "all");
+
+    expect(result).toBe(notificationsFixture);
+  });
+
+  it("returns only info notifications", () => {
+    const result = filterNotificationsByType(notificationsFixture, "info");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((notification: Notification) => notification.id)).toEqual(["t-1", "t-4"]);
+  });
+
+  it("returns only warning notifications", () => {
+    const result = filterNotificationsByType(notificationsFixture, "warning");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("t-2");
+  });
+
+  it("returns only error notifications", () => {
+    const result = filterNotificationsByType(notificationsFixture, "error");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("t-3");
+  });
+
+  it("returns an empty array when no notifications match the selected type", () => {
+    const warningsOnlyFixture: Notification[] = [
+      {
+        id: "w-1",
+        title: "Warning",
+        message: "Only warning present",
+        type: "warning",
+        timestamp: "2026-02-28T14:00:00.000Z",
+        read: false,
+      },
+    ];
+
+    const result = filterNotificationsByType(warningsOnlyFixture, "error");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not mutate the input array", () => {
+    const before = notificationsFixture.map((notification) => notification.id);
+
+    filterNotificationsByType(notificationsFixture, "warning");
+
+    expect(notificationsFixture.map((notification) => notification.id)).toEqual(before);
+  });
+
+  it("preserves source order when filtering", () => {
+    const result = filterNotificationsByType(mockNotifications, "warning");
+
+    expect(result.map((notification) => notification.id)).toEqual(["n-2", "n-5"]);
+  });
+
+  it("handles empty input arrays", () => {
+    const resultAll = filterNotificationsByType([], "all");
+    const resultInfo = filterNotificationsByType([], "info");
+
+    expect(resultAll).toEqual([]);
+    expect(resultInfo).toEqual([]);
+  });
+});
+
+describe("mockNotifications", () => {
+  it("contains unique notification ids", () => {
+    const ids = mockNotifications.map((notification) => notification.id);
+    const uniqueIds = new Set(ids);
+
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("contains at least one notification of every type", () => {
+    const types = new Set(mockNotifications.map((notification) => notification.type));
+
+    expect(types.has("info")).toBe(true);
+    expect(types.has("warning")).toBe(true);
+    expect(types.has("error")).toBe(true);
+  });
+
+  it("uses parseable ISO timestamps", () => {
+    for (const notification of mockNotifications) {
+      expect(Number.isNaN(Date.parse(notification.timestamp))).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Dark Factory — Automated PR

> Generated by pipeline job `cmm6wfbi000032se7x36i9yhw`
> ⚠️ This implementation required **2 retry iterations**

### Implementation Plan
1. **create** `src/types/notification.ts`
2. **create** `src/pages/notifications-page.tsx`
3. **modify** `src/pages/notifications-page.tsx`
4. **modify** `src/pages/notifications-page.tsx`
5. **modify** `src/pages/notifications-page.tsx`
6. **modify** `src/pages/notifications-page.tsx`
7. **modify** `src/pages/notifications-page.tsx`
8. **modify** `src/app/router-entry file(s) (project-specific)`
9. **modify** `src/components/navigation file(s) (project-specific)`
10. **create** `tests/notifications.test.ts`
11. **modify** `tests/notifications.test.ts`
12. **modify** `src/pages/notifications-page.tsx`
13. **modify** `tsconfig.json`
14. **modify** `package.json`
15. **modify** `(full project validation)`

### Code Review Verdict
⚠️ Not approved — 3 issue(s) noted

**Issues flagged:**
- [major] `src/App.tsx`: Routing is not reactive: `currentPath` is read once during render and there is no subscription to `popstate`/history changes. In-app navigation or browser back/forward will not update the rendered page unless something else forces a re-render. Use the app’s router (preferred) or add path state + `popstate` listener so `/dashboard/notifications` behaves as a real route.
- [minor] `tests/notifications.test.ts`: The test imports filtering logic from `src/pages/notifications-page.tsx`, coupling unit tests to a UI page module. Move `filterNotificationsByType` into a small utility module (e.g., `src/lib/notifications.ts`) and import from there to keep tests deterministic and avoid incidental page-level dependencies.
- [suggestion] `tests/notifications.test.ts`: Test placement is inconsistent with existing shown patterns (`src/**` tests). If Vitest include globs are restricted to `src`, this new `tests/notifications.test.ts` file may be skipped. Verify test discovery config or colocate under `src` to ensure acceptance criteria are actually validated in CI.

### Pipeline Cost
**Total: $0.5237 USD**

| Agent | Model | Notes |
|---|---|---|
| planner | gpt-5.3-codex | — |
| coder | gpt-5.3-codex | — |
| reviewer | gpt-5.3-codex | — |
| tester | gpt-5.3-codex | — |
| designer | gpt-5.3-codex | — |
| validator | gpt-5.3-codex | — |

---
_This PR was opened automatically by [Dark Factory v4](https://github.com/ibuzzardo/dark-factory-v4)._